### PR TITLE
Feat/remove profile picture

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,7 @@ export default [
         // Top-level and tools use Node
         files: [
             "tools/**/*.js",
+            "webpack.config.js",
         ],
         languageOptions: {
             globals: {

--- a/src/gui/src/UI/Settings/UITabAccount.js
+++ b/src/gui/src/UI/Settings/UITabAccount.js
@@ -35,55 +35,50 @@ export default {
 
         // profile picture
         h += `<div style="overflow: hidden; display: flex; margin-bottom: 20px; flex-direction: column; align-items: center;">`;
-            h += `<div class="profile-picture change-profile-picture" style="background-image: url('${html_encode(window.user?.profile?.picture ?? window.icons['profile.svg'])}');">`;
-            h += `</div>`;
-        // Add remove button only if user has a custom profile picture
-        if(window.user?.profile?.picture && window.user.profile.picture !== window.icons['profile.svg']){
-            h += `<button class="button remove-profile-picture" style="margin-top: 10px; background-color: #dc3545; color: black;">${i18n('remove_profile_picture')}</button>`;
-        }
-
+        h += `<div class="profile-picture change-profile-picture" style="background-image: url('${html_encode(window.user?.profile?.picture ?? window.icons['profile.svg'])}');">`;
+        h += `</div>`;
         h += `</div>`;
 
         // change password button
         if(!window.user.is_temp){
             h += `<div class="settings-card">`;
-                h += `<strong>${i18n('password')}</strong>`;
-                h += `<div style="flex-grow:1;">`;
-                    h += `<button class="button change-password" style="float:right;">${i18n('change_password')}</button>`;
-                h += `</div>`;
+            h += `<strong>${i18n('password')}</strong>`;
+            h += `<div style="flex-grow:1;">`;
+            h += `<button class="button change-password" style="float:right;">${i18n('change_password')}</button>`;
+            h += `</div>`;
             h += `</div>`;
         }
 
         // change username button
         h += `<div class="settings-card">`;
-            h += `<div>`;
-                h += `<strong style="display:block;">${i18n('username')}</strong>`;
-                h += `<span class="username" style="display:block; margin-top:5px;">${html_encode(window.user.username)}</span>`;
-            h += `</div>`;
-            h += `<div style="flex-grow:1;">`;
-                h += `<button class="button change-username" style="float:right;">${i18n('change_username')}</button>`;
-            h += `</div>`
+        h += `<div>`;
+        h += `<strong style="display:block;">${i18n('username')}</strong>`;
+        h += `<span class="username" style="display:block; margin-top:5px;">${html_encode(window.user.username)}</span>`;
+        h += `</div>`;
+        h += `<div style="flex-grow:1;">`;
+        h += `<button class="button change-username" style="float:right;">${i18n('change_username')}</button>`;
+        h += `</div>`
         h += `</div>`;
 
         // change email button
         if(window.user.email){
             h += `<div class="settings-card">`;
-                h += `<div>`;
-                    h += `<strong style="display:block;">${i18n('email')}</strong>`;
-                    h += `<span class="user-email" style="display:block; margin-top:5px;">${html_encode(window.user.email)}</span>`;
-                h += `</div>`;
-                h += `<div style="flex-grow:1;">`;
-                    h += `<button class="button change-email" style="float:right;">${i18n('change_email')}</button>`;
-                h += `</div>`;
+            h += `<div>`;
+            h += `<strong style="display:block;">${i18n('email')}</strong>`;
+            h += `<span class="user-email" style="display:block; margin-top:5px;">${html_encode(window.user.email)}</span>`;
+            h += `</div>`;
+            h += `<div style="flex-grow:1;">`;
+            h += `<button class="button change-email" style="float:right;">${i18n('change_email')}</button>`;
+            h += `</div>`;
             h += `</div>`;
         }
 
         // 'Delete Account' button
         h += `<div class="settings-card settings-card-danger">`;
-            h += `<strong style="display: inline-block;">${i18n("delete_account")}</strong>`;
-            h += `<div style="flex-grow:1;">`;
-                h += `<button class="button button-danger delete-account" style="float:right;">${i18n("delete_account")}</button>`;
-            h += `</div>`;
+        h += `<strong style="display: inline-block;">${i18n("delete_account")}</strong>`;
+        h += `<div style="flex-grow:1;">`;
+        h += `<button class="button button-danger delete-account" style="float:right;">${i18n("delete_account")}</button>`;
+        h += `</div>`;
         h += `</div>`;
 
         return h;
@@ -139,9 +134,11 @@ export default {
             });
         });
 
-        $el_window.on('click', '.change-profile-picture', async function (e) {
+        $el_window.find('.change-profile-picture').on('click', async function (e) {
+            // open dialog
             UIWindow({
                 path: '/' + window.user.username + '/Desktop',
+                // this is the uuid of the window to which this dialog will return
                 parent_uuid: $el_window.attr('data-element_uuid'),
                 allowed_file_types: ['.png', '.jpg', '.jpeg'],
                 show_maximize_button: false,
@@ -151,58 +148,34 @@ export default {
                 is_openFileDialog: true,
                 selectable_body: false,
             });
-        });
+        })
 
-        // Use event delegation for the remove button
-        $el_window.on('click', '.remove-profile-picture', function (e) {
-            window.update_profile(window.user.username, {picture: null});
-            $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(window.icons['profile.svg']) + ')');
-            $('.profile-image').css('background-image', 'url(' + html_encode(window.icons['profile.svg']) + ')');
-            $('.profile-image').removeClass('profile-image-has-picture');
-            $(this).remove();
-        });
-
-        $el_window.on('file_opened', async function (e) {
+        $el_window.on('file_opened', async function(e){
             let selected_file = Array.isArray(e.detail) ? e.detail[0] : e.detail;
-
-            try {
-                const response = await fetch(selected_file.read_url);
-                if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
+            // set profile picture
+            const profile_pic = await puter.fs.read(selected_file.path)
+            // blob to base64
+            const reader = new FileReader();
+            reader.readAsDataURL(profile_pic);
+            reader.onloadend = function() {
+                // resizes the image to 150x150
+                const img = new Image();
+                img.src = reader.result;
+                img.onload = function() {
+                    const canvas = document.createElement('canvas');
+                    const ctx = canvas.getContext('2d');
+                    canvas.width = 150;
+                    canvas.height = 150;
+                    ctx.drawImage(img, 0, 0, 150, 150);
+                    const base64data = canvas.toDataURL('image/png');
+                    // update profile picture
+                    $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(base64data) + ')');
+                    $('.profile-image').css('background-image', 'url(' + html_encode(base64data) + ')');
+                    $('.profile-image').addClass('profile-image-has-picture');
+                    // update profile picture
+                    update_profile(window.user.username, {picture: base64data})
                 }
-                const profile_pic = await response.blob();
-
-                const reader = new FileReader();
-                reader.readAsDataURL(profile_pic);
-                reader.onloadend = function () {
-                    const img = new Image();
-                    img.src = reader.result;
-                    img.onload = function () {
-                        const canvas = document.createElement('canvas');
-                        const ctx = canvas.getContext('2d');
-                        canvas.width = 150;
-                        canvas.height = 150;
-                        ctx.drawImage(img, 0, 0, 150, 150);
-                        const base64data = canvas.toDataURL('image/png');
-
-                        // update profile picture
-                        $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(base64data) + ')');
-                        $('.profile-image').css('background-image', 'url(' + html_encode(base64data) + ')');
-                        $('.profile-image').addClass('profile-image-has-picture');
-
-                        window.update_profile(window.user.username, {picture: base64data});
-
-                        // Add the remove button only if it doesn't exist
-                        if ($el_window.find('.remove-profile-picture').length === 0) {
-                            $el_window.find('.profile-picture').parent().append(
-                                `<button class="button remove-profile-picture" style="margin-top: 10px; background-color: #dc3545; color: black;">${i18n('remove_profile_picture')}</button>`
-                            );
-                        }
-                    }
-                }
-            } catch (error) {
-                console.error('Error reading profile picture:', error);
             }
-        });
-    }
-    }
+        })
+    },
+};

--- a/src/gui/src/UI/Settings/UITabAccount.js
+++ b/src/gui/src/UI/Settings/UITabAccount.js
@@ -37,6 +37,11 @@ export default {
         h += `<div style="overflow: hidden; display: flex; margin-bottom: 20px; flex-direction: column; align-items: center;">`;
             h += `<div class="profile-picture change-profile-picture" style="background-image: url('${html_encode(window.user?.profile?.picture ?? window.icons['profile.svg'])}');">`;
             h += `</div>`;
+        // Add remove button only if user has a custom profile picture
+        if(window.user?.profile?.picture && window.user.profile.picture !== window.icons['profile.svg']){
+            h += `<button class="button remove-profile-picture" style="margin-top: 10px; background-color: #dc3545; color: black;">${i18n('remove_profile_picture')}</button>`;
+        }
+
         h += `</div>`;
 
         // change password button
@@ -134,11 +139,9 @@ export default {
             });
         });
 
-        $el_window.find('.change-profile-picture').on('click', async function (e) {
-            // open dialog
+        $el_window.on('click', '.change-profile-picture', async function (e) {
             UIWindow({
                 path: '/' + window.user.username + '/Desktop',
-                // this is the uuid of the window to which this dialog will return
                 parent_uuid: $el_window.attr('data-element_uuid'),
                 allowed_file_types: ['.png', '.jpg', '.jpeg'],
                 show_maximize_button: false,
@@ -147,35 +150,59 @@ export default {
                 is_dir: true,
                 is_openFileDialog: true,
                 selectable_body: false,
-            });    
-        })
+            });
+        });
 
-        $el_window.on('file_opened', async function(e){
+        // Use event delegation for the remove button
+        $el_window.on('click', '.remove-profile-picture', function (e) {
+            window.update_profile(window.user.username, {picture: null});
+            $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(window.icons['profile.svg']) + ')');
+            $('.profile-image').css('background-image', 'url(' + html_encode(window.icons['profile.svg']) + ')');
+            $('.profile-image').removeClass('profile-image-has-picture');
+            $(this).remove();
+        });
+
+        $el_window.on('file_opened', async function (e) {
             let selected_file = Array.isArray(e.detail) ? e.detail[0] : e.detail;
-            // set profile picture
-            const profile_pic = await puter.fs.read(selected_file.path)
-            // blob to base64
-            const reader = new FileReader();
-            reader.readAsDataURL(profile_pic);
-            reader.onloadend = function() {
-                // resizes the image to 150x150
-                const img = new Image();
-                img.src = reader.result;
-                img.onload = function() {
-                    const canvas = document.createElement('canvas');
-                    const ctx = canvas.getContext('2d');
-                    canvas.width = 150;
-                    canvas.height = 150;
-                    ctx.drawImage(img, 0, 0, 150, 150);
-                    const base64data = canvas.toDataURL('image/png');
-                    // update profile picture
-                    $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(base64data) + ')');
-                    $('.profile-image').css('background-image', 'url(' + html_encode(base64data) + ')');
-                    $('.profile-image').addClass('profile-image-has-picture');
-                    // update profile picture
-                    update_profile(window.user.username, {picture: base64data})
+
+            try {
+                const response = await fetch(selected_file.read_url);
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
                 }
+                const profile_pic = await response.blob();
+
+                const reader = new FileReader();
+                reader.readAsDataURL(profile_pic);
+                reader.onloadend = function () {
+                    const img = new Image();
+                    img.src = reader.result;
+                    img.onload = function () {
+                        const canvas = document.createElement('canvas');
+                        const ctx = canvas.getContext('2d');
+                        canvas.width = 150;
+                        canvas.height = 150;
+                        ctx.drawImage(img, 0, 0, 150, 150);
+                        const base64data = canvas.toDataURL('image/png');
+
+                        // update profile picture
+                        $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(base64data) + ')');
+                        $('.profile-image').css('background-image', 'url(' + html_encode(base64data) + ')');
+                        $('.profile-image').addClass('profile-image-has-picture');
+
+                        window.update_profile(window.user.username, {picture: base64data});
+
+                        // Add the remove button only if it doesn't exist
+                        if ($el_window.find('.remove-profile-picture').length === 0) {
+                            $el_window.find('.profile-picture').parent().append(
+                                `<button class="button remove-profile-picture" style="margin-top: 10px; background-color: #dc3545; color: black;">${i18n('remove_profile_picture')}</button>`
+                            );
+                        }
+                    }
+                }
+            } catch (error) {
+                console.error('Error reading profile picture:', error);
             }
-        })
-    },
-};
+        });
+    }
+    }

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -237,6 +237,7 @@ const en = {
         refer_friends_social_media_c2a: `Get 1 GB of free storage on Puter.com!`,
         refresh: 'Refresh',
         release_address_confirmation: `Are you sure you want to release this address?`,
+        remove_profile_picture: 'Remove Profile Picture',
         remove_from_taskbar:'Remove from Taskbar',
         rename: 'Rename',
         repeat: 'Repeat',

--- a/src/gui/src/util/desktop.js
+++ b/src/gui/src/util/desktop.js
@@ -1,26 +1,29 @@
 /**
  * This file contains functions that are used by Puter's desktop GUI.
- * Functions moved here are not bound to the `window` object, making it
+ * Functions moved here are not bound to the window object, making it
  * easier to write unit tests for them.
- * 
- * Functions here may be bound to `window` at any of the following locations:
+ *
+ * Functions here may be bound to window at any of the following locations:
  * - src/gui/src/initgui.js
- * 
+ *
  * ^ Please add to the above list as necessary when moving functions here.
  */
 
 /**
  * Converts a file system path to a privacy-aware path.
- * - Paths starting with `~/` are returned unchanged.
- * - Paths starting with the user's home path are replaced with `~`.
+ * - Paths starting with ~/ are returned unchanged.
+ * - Paths starting with the user's home path are replaced with ~.
  * - Absolute paths not starting with the user's home path are returned unchanged.
- * - Relative paths are prefixed with `~/`.
+ * - Relative paths are prefixed with ~/.
  * - Other paths are returned unchanged.
  *
  * @param {string} fspath - The file system path to be converted.
  * @returns {string} The privacy-aware path.
  */
 export const privacy_aware_path = world => function privacy_aware_path (fspath) {
+    // normalize backslashes to forward slashes (Windows compatibility)
+    fspath = fspath.replace(/\\/g, '/');
+
     // e.g. /my_username/test.txt -> ~/test.txt
     if(fspath.startsWith('~/'))
         return fspath;


### PR DESCRIPTION
Fixes #1 
This PR adds the ability for users to remove their custom profile picture and revert to the default avatar.
Changes Made:
Profile Picture Management:

Added a "Remove Profile Picture" button that appears conditionally when a user has uploaded a custom profile picture
Implemented functionality to reset the profile picture to the default icon across all UI instances
The remove button dynamically appears after uploading a new picture and is hidden when using the default avatar

Code Quality Improvements:

Refactored HTML generation in UITabAccount.js to improve indentation consistency and readability
Fixed trailing whitespace issues
Cleaned up code formatting throughout the account settings component

Internationalization:

Added remove_profile_picture translation key to support the new feature

Development Setup:

Updated ESLint configuration to include webpack.config.js for Windows development environment compatibility

Utilities:

Enhanced privacy_aware_path function with better documentation and added backslash-to-forward-slash normalization for Windows path compatibility

User Experience:
Users can now easily remove their custom profile pictures without needing to upload a new image, providing a cleaner way to manage their account appearance.


Before Fix:
<img width="1917" height="944" alt="image" src="https://github.com/user-attachments/assets/18b89ed6-213c-41cd-86e9-bff4b9feae46" />

After Fix:
<img width="1915" height="946" alt="after" src="https://github.com/user-attachments/assets/afafc339-394d-4a5a-9a52-9ec5933191c3" />

Video Walkthrough:
https://youtu.be/3MWm6h7dw3k

