### PR TITLE
Add auto-hide functionality to toolbar

### DIFF
--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -1145,6 +1145,73 @@ async function UIDesktop(options){
     // prepend toolbar to desktop
     $(ht).insertBefore(el_desktop);
 
+    // toolbar auto-hide functionality
+    (function initDynamicToolbar() {
+        let toolbarHideTimer = null;
+        let isToolbarVisible = true;
+        const HIDE_DELAY = 2000; // 2 seconds of inactivity
+        const MOUSE_PROXIMITY_THRESHOLD = 50;
+
+        const $toolbar = $('.toolbar');
+
+        function hideToolbar() {
+            if (isToolbarVisible) {
+                $toolbar.addClass('toolbar-hidden');
+                isToolbarVisible = false;
+            }
+        }
+
+        function showToolbar() {
+            if (!isToolbarVisible) {
+                $toolbar.removeClass('toolbar-hidden');
+                isToolbarVisible = true;
+            }
+            resetHideTimer();
+        }
+
+        function resetHideTimer() {
+            if (toolbarHideTimer) {
+                clearTimeout(toolbarHideTimer);
+            }
+            toolbarHideTimer = setTimeout(hideToolbar, HIDE_DELAY);
+        }
+
+        // Start the initial hide timer
+        resetHideTimer();
+
+        // Show toolbar when mouse moves near the top of the screen
+        $(document).on('mousemove', function(e) {
+            if (e.clientY <= MOUSE_PROXIMITY_THRESHOLD) {
+                showToolbar();
+            } else if (e.clientY > window.toolbar_height && isToolbarVisible) {
+                // Reset timer when mouse moves away from toolbar area
+                resetHideTimer();
+            }
+        });
+
+        // Keep toolbar visible when hovering over it
+        $toolbar.on('mouseenter', function() {
+            if (toolbarHideTimer) {
+                clearTimeout(toolbarHideTimer);
+            }
+        });
+
+        // Restart hide timer when mouse leaves toolbar
+        $toolbar.on('mouseleave', function() {
+            resetHideTimer();
+        });
+
+        // Show toolbar on any click event
+        $(document).on('click', function() {
+            showToolbar();
+        });
+
+        // Show toolbar when any toolbar button is interacted with
+        $(document).on('click', '.toolbar-btn', function() {
+            showToolbar();
+        });
+    })();
+
     // notification container
     $('body').append(`<div class="notification-container"><div class="notifications-close-all">${i18n('close_all')}</div></div>`);
 

--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -1740,7 +1740,9 @@ label {
     width: 100%;
     background-color: #00000040;
     height: 30px;
-    position: relative;
+    position: fixed;
+    top: 0;
+    left: 0;
     z-index: 999999;
     box-sizing: border-box;
     display: flex;
@@ -1748,7 +1750,16 @@ label {
     justify-content: flex-end;
     align-content: center;
     flex-wrap: wrap;
-    padding-right: 10px
+    padding-right: 10px;
+    transform: translateY(0);
+    transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+    opacity: 1;
+}
+
+.toolbar.toolbar-hidden {
+    transform: translateY(-100%);
+    opacity: 0;
+    pointer-events: none;
 }
 
 .show-desktop-btn {


### PR DESCRIPTION
Introduces dynamic auto-hide behavior for the toolbar in UIDesktop.js, making it hide after inactivity and reappear on mouse proximity or interaction. Updates CSS to support fixed positioning and smooth transitions for toolbar visibility.

Before:
<img width="2559" height="1336" alt="image" src="https://github.com/user-attachments/assets/2bb092ba-8e99-4a39-9c66-41d5bc44590a" />

After (2 seconds of inactivity):
<img width="2557" height="1323" alt="image" src="https://github.com/user-attachments/assets/8c8c6e57-14dc-442d-b2e6-2e463d6fc7ed" />

Video:
https://youtu.be/QyzPOgbTty0