### PR TITLE
Add option to show/hide desktop icons

### DIFF
--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -708,6 +708,7 @@ async function UIDesktop(options){
     // update local user preferences
     const user_preferences = {
         show_hidden_files: JSON.parse(await puter.kv.get('user_preferences.show_hidden_files')),
+        show_desktop_icons: JSON.parse(await puter.kv.get('user_preferences.show_desktop_icons')) ?? true,
         language: await puter.kv.get('user_preferences.language'),
         clock_visible: await puter.kv.get('user_preferences.clock_visible'),
     };
@@ -719,6 +720,9 @@ async function UIDesktop(options){
         }
 
         window.update_user_preferences(user_preferences);
+
+        // Apply desktop icons visibility preference
+        window.toggle_desktop_icons_visibility?.();
     });
 
     // Append to <body>
@@ -941,6 +945,19 @@ async function UIDesktop(options){
                                 show_hidden_files : !window.user_preferences.show_hidden_files,
                             });
                             window.show_or_hide_files(document.querySelectorAll('.item-container'));
+                        }
+                    },
+                    // -------------------------------------------
+                    // Show/Hide desktop icons
+                    // -------------------------------------------
+                    {
+                        html: window.user_preferences.show_desktop_icons ? i18n('hide_desktop_icons') : i18n('show_desktop_icons'),
+                        icon: '',
+                        onClick: function(){
+                            window.mutate_user_preferences({
+                                show_desktop_icons : !window.user_preferences.show_desktop_icons,
+                            });
+                            window.toggle_desktop_icons_visibility();
                         }
                     },
                     // -------------------------------------------

--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -409,6 +409,10 @@ input[type=text]:focus, input[type=password]:focus, input[type=email]:focus, sel
     opacity: 0.7
 }
 
+.desktop.icons-hidden .item {
+    display: none !important;
+}
+
 .item-container-list .item {
     height: initial;
     width: max-content;

--- a/src/gui/src/helpers.js
+++ b/src/gui/src/helpers.js
@@ -780,6 +780,17 @@ window.show_or_hide_files = (item_containers) => {
         .removeClass(class_to_remove).addClass(class_to_add);
 }
 
+window.toggle_desktop_icons_visibility = () => {
+    const show_desktop_icons = window.user_preferences.show_desktop_icons;
+    const desktop = document.querySelector('.desktop');
+
+    if (show_desktop_icons) {
+        desktop?.classList.remove('icons-hidden');
+    } else {
+        desktop?.classList.add('icons-hidden');
+    }
+}
+
 window.create_folder = async(basedir, appendto_element)=>{
 	let dirname = basedir;
     let folder_name = 'New Folder';

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -274,6 +274,8 @@ const en = {
         shortcut_to: "Shortcut to",
         show_all_windows: "Show All Windows",
         show_hidden: 'Show hidden',
+        show_desktop_icons: 'Show Desktop Icons',
+        hide_desktop_icons: 'Hide Desktop Icons',
         sign_in_with_puter: "Sign in with Puter",
         sign_up: "Sign Up",
         signing_in: "Signing in…",


### PR DESCRIPTION
Introduces a user preference for toggling desktop icon visibility. Updates UI, CSS, helpers, and translations to support showing or hiding desktop icons based on user settings.

Before
<img width="2554" height="1326" alt="image" src="https://github.com/user-attachments/assets/f87a7f80-fef1-459e-9001-338c11908cbf" />


After
<img width="2544" height="1309" alt="image" src="https://github.com/user-attachments/assets/77ff61ef-4c46-4e13-a0f9-e6f03dc00b9d" />
<img width="2537" height="1323" alt="image" src="https://github.com/user-attachments/assets/fb105b22-6387-4094-91b7-d931a9fb4e93" />
